### PR TITLE
Gallerycards mobile responsiveness

### DIFF
--- a/src/components/gallery/GalleryCards.jsx
+++ b/src/components/gallery/GalleryCards.jsx
@@ -20,37 +20,37 @@ const GalleryCards = ({ cards }) => {
   };
 
   return (
-    <div>
-      <div
-        style={{ display: "flex", flexWrap: "nowrap" }}
-        className="w-full flex justify-center items-center flex-wrap w-full"
+    <div
+      style={{ display: "flex", flexWrap: "nowrap" }}
+      className="w-4/6 flex justify-center items-center w-full"
+    >
+      <button
+        onClick={handleLeftClick}
+        className="flex justify-center items-center"
       >
-        <button onClick={handleLeftClick}>
-          <div className="text-5xl text-art-pink-400 hover:text-art-purple-300">
-            <FaAngleLeft />
-          </div>
-        </button>
-        <div className="m-4 w-60 h-60 rounded-xl flex justify-center items-center bg-art-purple-100">
-          <div className="flex items-center justify-center">
-            <Image src={cards[currentCardIndex].image} alt="Image" />
-          </div>
-        </div>
-        <div className="m-4 w-60 h-60 rounded-xl flex justify-center items-center bg-art-purple-100 hidden sm:block">
-          <div className="flex items-center justify-center">
-            <Image src={cards[currentCardIndex + 1].image} alt="Image" />
-          </div>
-        </div>
-        <div className="m-4 w-60 h-60 rounded-xl flex justify-center items-center bg-art-purple-100 hidden md:block">
-          <div className="flex items-center justify-center">
-            <Image src={cards[currentCardIndex + 2].image} alt="Image" />
-          </div>
-        </div>
-        <button onClick={handleRightClick}>
-          <div className="text-5xl text-art-pink-400 hover:text-art-purple-300">
-            <FaAngleRight />
-          </div>
-        </button>
-      </div>
+        <FaAngleLeft className="text-5xl text-art-pink-400 hover:text-art-purple-300" />
+      </button>
+      <Image
+        src={cards[currentCardIndex].image}
+        alt="Image"
+        className="w-60 h-60 rounded-xl flex justify-center items-center bg-art-purple-100"
+      />
+      <Image
+        src={cards[currentCardIndex + 1].image}
+        alt="Image"
+        className="ml-4 w-60 h-60 rounded-xl flex justify-center items-center bg-art-purple-100 hidden lg:block"
+      />
+      <Image
+        src={cards[currentCardIndex + 2].image}
+        alt="Image"
+        className="ml-4 w-60 h-60 rounded-xl flex justify-center items-center bg-art-purple-100 hidden sm:block"
+      />
+      <button
+        onClick={handleRightClick}
+        className="flex justify-center items-center"
+      >
+        <FaAngleRight className="text-5xl text-art-pink-400 hover:text-art-purple-300" />
+      </button>
     </div>
   );
 };

--- a/src/components/gallery/GalleryCards.jsx
+++ b/src/components/gallery/GalleryCards.jsx
@@ -21,24 +21,30 @@ const GalleryCards = ({ cards }) => {
 
   return (
     <div>
-      <div className="flex justify-center flex-wrap w-full">
+      <div
+        style={{ display: "flex", flexWrap: "nowrap" }}
+        className="w-full flex justify-center items-center flex-wrap w-full"
+      >
         <button onClick={handleLeftClick}>
           <div className="text-5xl text-art-pink-400 hover:text-art-purple-300">
             <FaAngleLeft />
           </div>
         </button>
-        {cards
-          .slice(currentCardIndex, currentCardIndex + 3)
-          .map((card, index) => (
-            <div
-              key={index}
-              className={
-                "m-4 w-80 h-80 rounded-xl flex justify-center items-center bg-art-purple-100"
-              }
-            >
-              <Image src={card.image} alt="Image" />
-            </div>
-          ))}
+        <div className="m-4 w-60 h-60 rounded-xl flex justify-center items-center bg-art-purple-100">
+          <div className="flex items-center justify-center">
+            <Image src={cards[currentCardIndex].image} alt="Image" />
+          </div>
+        </div>
+        <div className="m-4 w-60 h-60 rounded-xl flex justify-center items-center bg-art-purple-100 hidden sm:block">
+          <div className="flex items-center justify-center">
+            <Image src={cards[currentCardIndex + 1].image} alt="Image" />
+          </div>
+        </div>
+        <div className="m-4 w-60 h-60 rounded-xl flex justify-center items-center bg-art-purple-100 hidden md:block">
+          <div className="flex items-center justify-center">
+            <Image src={cards[currentCardIndex + 2].image} alt="Image" />
+          </div>
+        </div>
         <button onClick={handleRightClick}>
           <div className="text-5xl text-art-pink-400 hover:text-art-purple-300">
             <FaAngleRight />


### PR DESCRIPTION
<img width="309" alt="Screenshot 2024-04-21 at 5 58 55 PM" src="https://github.com/acm-ucr/art-factory-website/assets/74474117/2809257d-4065-4c37-b841-5f2127ec3e83">
<img width="309" alt="Screenshot 2024-04-21 at 5 59 19 PM" src="https://github.com/acm-ucr/art-factory-website/assets/74474117/d2420986-a7cc-4e39-a1f1-31dddf048a34">
<img width="400" alt="Screenshot 2024-04-21 at 5 59 38 PM" src="https://github.com/acm-ucr/art-factory-website/assets/74474117/2108c8bc-1ffb-4aa6-b0ae-d86f9c1806de">

* The first image is the way how it looks on a Samsung Fold (Thinnest screen) when loading into the page
* The second image is when you zoom out. It looks like it is no longer centered but I have my suspicions that is because of the Join button since it is outside the blue line on top
* The third image is how it looks on regular sized tablets

Let me know what to change.

