### PR TITLE
Adjust gallerycards

### DIFF
--- a/src/app/about/page.js
+++ b/src/app/about/page.js
@@ -4,11 +4,9 @@ import React from "react";
 
 const page = () => {
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center gap-16">
       <AboutLanding />
-      <div className=" mt-16">
-        <About />
-      </div>
+      <About />
     </div>
   );
 };

--- a/src/components/gallery/GalleryCards.jsx
+++ b/src/components/gallery/GalleryCards.jsx
@@ -53,7 +53,7 @@ const GalleryCards = ({ cards, title }) => {
           onClick={handleRightClick}
           className="flex justify-center items-center"
         >
-          <FaAngleRight className="max-[490px]:text-6xl text-8xl text-art-pink-400 hover:text-art-purple-300" />
+          <FaAngleRight className="md:text-8xl text-6xl text-art-pink-400 hover:text-art-purple-300" />
         </button>
       </div>
     </div>

--- a/src/components/gallery/GalleryCards.jsx
+++ b/src/components/gallery/GalleryCards.jsx
@@ -32,28 +32,28 @@ const GalleryCards = ({ cards, title }) => {
           onClick={handleLeftClick}
           className="flex justify-center items-center"
         >
-          <FaAngleLeft className="text-8xl text-art-pink-400 hover:text-art-purple-300" />
+          <FaAngleLeft className="max-[490px]:text-6xl text-8xl text-art-pink-400 hover:text-art-purple-300" />
         </button>
         <Image
           src={cards[currentCardIndex].image}
           alt="Image"
-          className="w-80 h-80 rounded-xl flex justify-center items-center bg-art-purple-100"
+          className="max-[490px]:w-60 max-[490px]:h-60 w-80 h-80 rounded-xl flex justify-center items-center bg-art-purple-100"
         />
         <Image
           src={cards[currentCardIndex + 1].image}
           alt="Image"
-          className="ml-4 w-80 h-80 rounded-xl justify-center items-center bg-art-purple-100 hidden lg:block"
+          className="ml-4 w-80 h-80 rounded-xl justify-center items-center bg-art-purple-100 hidden md:block"
         />
         <Image
           src={cards[currentCardIndex + 2].image}
           alt="Image"
-          className="ml-4 w-80 h-80 rounded-xl justify-center items-center bg-art-purple-100 hidden md:block"
+          className="ml-4 w-80 h-80 rounded-xl justify-center items-center bg-art-purple-100 hidden lg:block"
         />
         <button
           onClick={handleRightClick}
           className="flex justify-center items-center"
         >
-          <FaAngleRight className="text-8xl text-art-pink-400 hover:text-art-purple-300" />
+          <FaAngleRight className="max-[490px]:text-6xl text-8xl text-art-pink-400 hover:text-art-purple-300" />
         </button>
       </div>
     </div>

--- a/src/components/gallery/GalleryCards.jsx
+++ b/src/components/gallery/GalleryCards.jsx
@@ -23,33 +23,33 @@ const GalleryCards = ({ cards, title }) => {
   return (
     <div className=" flex justify-center flex-col items-center w-full gap-6 mb-3">
       <GalleryHeader text={title} />
-      <div className="flex w-full justify-center gap-10 mt-2">
+      <div className="flex w-full justify-center justify-between mt-2">
         <button
           onClick={handleLeftClick}
           className="flex justify-center items-center"
         >
-          <FaAngleLeft className="text-5xl text-art-pink-400 hover:text-art-purple-300" />
+          <FaAngleLeft className="text-8xl text-art-pink-400 hover:text-art-purple-300" />
         </button>
         <Image
           src={cards[currentCardIndex].image}
           alt="Image"
-          className="w-60 h-60 rounded-xl flex justify-center items-center bg-art-purple-100"
+          className="w-80 h-80 rounded-xl flex justify-center items-center bg-art-purple-100"
         />
         <Image
           src={cards[currentCardIndex + 1].image}
           alt="Image"
-          className="ml-4 w-60 h-60 rounded-xl justify-center items-center bg-art-purple-100 hidden lg:block"
+          className="ml-4 w-80 h-80 rounded-xl justify-center items-center bg-art-purple-100 hidden lg:block"
         />
         <Image
           src={cards[currentCardIndex + 2].image}
           alt="Image"
-          className="ml-4 w-60 h-60 rounded-xl justify-center items-center bg-art-purple-100 hidden sm:block"
+          className="ml-4 w-80 h-80 rounded-xl justify-center items-center bg-art-purple-100 hidden md:block"
         />
         <button
           onClick={handleRightClick}
           className="flex justify-center items-center"
         >
-          <FaAngleRight className="text-5xl text-art-pink-400 hover:text-art-purple-300" />
+          <FaAngleRight className="text-8xl text-art-pink-400 hover:text-art-purple-300" />
         </button>
       </div>
     </div>

--- a/src/components/gallery/GalleryCards.jsx
+++ b/src/components/gallery/GalleryCards.jsx
@@ -27,17 +27,17 @@ const GalleryCards = ({ cards, title }) => {
   return (
     <div className=" flex justify-center flex-col items-center w-full gap-6 mb-3">
       <GalleryHeader text={title} />
-      <div className="flex w-full justify-center justify-between mt-2">
+      <div className="flex w-full justify-between mt-2">
         <button
           onClick={handleLeftClick}
           className="flex justify-center items-center"
         >
-          <FaAngleLeft className="max-[490px]:text-6xl text-8xl text-art-pink-400 hover:text-art-purple-300" />
+          <FaAngleLeft className="md:text-8xl text-6xl text-art-pink-400 hover:text-art-purple-300" />
         </button>
         <Image
           src={cards[currentCardIndex].image}
           alt="Image"
-          className="max-[490px]:w-60 max-[490px]:h-60 w-80 h-80 rounded-xl flex justify-center items-center bg-art-purple-100"
+          className="md:w-80 md:h-80 w-60 h-60 rounded-xl flex justify-center items-center bg-art-purple-100"
         />
         <Image
           src={cards[currentCardIndex + 1].image}


### PR DESCRIPTION
<img width="1430" alt="image" src="https://github.com/acm-ucr/art-factory-website/assets/74474117/f2e96429-0871-4c4c-825c-acc9125b4868">

<img width="183" alt="image" src="https://github.com/acm-ucr/art-factory-website/assets/74474117/454520af-bcde-494d-87f9-903afa24e9d6">

* Used justify-between
* Updated the size of each card and arrows to be larger
* Added breakpoints to look good on very thin phones like a fold
* Second picture is how it looks like on a galaxy z fold 5

Let me know if you want it even larger
