### PR TITLE
Board Cards/Headers Responsiveness

### DIFF
--- a/src/components/board/Board.jsx
+++ b/src/components/board/Board.jsx
@@ -5,12 +5,12 @@ const Board = ({ name, title, image }) => {
       <div className="w-[70%] translate-y-1/2 border-[1px] border-art-purple bg-white rounded-full text-art-purple text-sm md:text-lg font-semibold z-10 flex justify-center">
         {title}
       </div>
-      <div className="w-[90%] border-[3px] md:border-[6.5px] border-art-purple rounded-full py-[3.75px] md:py-[0px] px-[4px] md:px-[1px] drop-shadow-[4px_5px_0px_rgba(205,164,229,255)]">
+      <div className="w-[90%] border-[3px] md:border-[6.5px] border-art-purple rounded-full py-[3.75px] md:py-0 px-[4px] md:px-1 drop-shadow-[4px_5px_0px_rgba(205,164,229,255)]">
         <div className="pt-2 pb-1 px-2 bg-art-purple-300 ring-4 ring-offset-[1.5px] ring-art-pink-400 ring-offset-art-purple  text-white text-xs md:text-base lg:text-lg xl:text-2xl font-bold rounded-full">
           {name}
         </div>
       </div>
-      <div className="m-4 p-3 rounded-xl shadow-md bg-art-purple-100">
+      <div className="m-4 p-2 md:p-3 rounded-xl shadow-md bg-art-purple-100">
         <Image src={image} alt={"profilepic"} className="rounded-lg" />
       </div>
     </div>

--- a/src/components/board/Board.jsx
+++ b/src/components/board/Board.jsx
@@ -5,12 +5,12 @@ const Board = ({ name, title, image }) => {
       <div className="w-[70%] translate-y-1/2 border-[1px] border-art-purple bg-white rounded-full text-art-purple text-sm md:text-lg font-semibold z-10 flex justify-center">
         {title}
       </div>
-      <div className="w-[80%] border-[3px] md:border-[6.5px] border-art-purple rounded-full py-[3.75px] md:py-[0px] px-[4px] md:px-[1px] drop-shadow-[4px_5px_0px_rgba(205,164,229,255)]">
-        <div className="pt-2 pb-1 px-8 md:px-12 bg-art-purple-300 ring-4 ring-offset-[1.5px] ring-art-pink-400 ring-offset-art-purple  text-white text-sm md:text-lg font-bold rounded-full">
+      <div className="w-[90%] border-[3px] md:border-[6.5px] border-art-purple rounded-full py-[3.75px] md:py-[0px] px-[4px] md:px-[1px] drop-shadow-[4px_5px_0px_rgba(205,164,229,255)]">
+        <div className="pt-2 pb-1 px-2 bg-art-purple-300 ring-4 ring-offset-[1.5px] ring-art-pink-400 ring-offset-art-purple  text-white text-xs md:text-base lg:text-lg xl:text-2xl font-bold rounded-full">
           {name}
         </div>
       </div>
-      <div className="m-4 p-4 rounded-xl shadow-md bg-art-purple-100">
+      <div className="m-4 p-3 rounded-xl shadow-md bg-art-purple-100">
         <Image src={image} alt={"profilepic"} className="rounded-lg" />
       </div>
     </div>

--- a/src/components/board/Boards.jsx
+++ b/src/components/board/Boards.jsx
@@ -4,7 +4,7 @@ import { Board } from "../../data/board.js";
 const Boards = () => {
   return (
     <div className="w-5/6">
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
         {Board.map((CARD, index) => (
           <Card
             name={CARD.name}


### PR DESCRIPTION
-decreased x-padding on header text for flat/aligned grid spaces
-fixed grid column arrangement for different screen sizes

sm:
![image](https://github.com/acm-ucr/art-factory-website/assets/117532511/25dd4044-2b30-4da6-be59-39051c388def)

md:
![image](https://github.com/acm-ucr/art-factory-website/assets/117532511/1590147b-1270-4b85-9038-b32179d06aca)

lg/xl: 
![image](https://github.com/acm-ucr/art-factory-website/assets/117532511/c78f490a-7b61-4c4b-bbdf-652e6976868d)

fixes #68 