### PR TITLE
Fixed responsiveness for Landing page

### DIFF
--- a/src/components/about/AboutLanding.jsx
+++ b/src/components/about/AboutLanding.jsx
@@ -10,17 +10,20 @@ const AboutLanding = () => {
       <Image
         src={left}
         alt="leftring"
-        className="absolute -left-[9%] top-[67%] w-64 rotate-3"
+        className="absolute left-[-2%]  top-[74%]  w-36 rotate-6 sm:-left-[3%] sm:top-[69%] sm:w-60 sm:rotate-3"
       />
 
-      <div className="bg-gradient-to-r from-art-purple-200 to-art-pink-100 bg-clip-text text-transparent text-6xl tracking-[25px] drop-shadow-xl font-bold mt-20 p-1">
+      <div className="bg-gradient-to-r from-art-purple-200 to-art-pink-100 bg-clip-text text-transparent ml-6 sm:ml-7 sm:0 text-4xl sm:text-6xl tracking-[10px] sm:tracking-[23px] drop-shadow-xl font-bold mt-20 p-1">
         Art Factory
       </div>
 
-      <div className="mt-3 flex items-center bg-art-purple-100 rounded-full px-3 w-96 h-9 ml-10">
-        <Image src={logo} alt="landingLogo" className=" w-10 mt-3" />
-        <p className="text-white tracking-[2px] mx-auto">
-          {" "}
+      <div className="flex items-center bg-art-purple-100 rounded-full mt-1 px-3 w-50 h-7 ml-3 sm:mt-3 sm:px-3 sm:w-96 sm:h-9 sm:ml-10">
+        <Image
+          src={logo}
+          alt="landingLogo"
+          className=" w-7 mt-3 mr-1 sm:mr-0 sm:w-10 sm:mt-3"
+        />
+        <p className="text-white tracking-[2px] text-xs mx-auto">
           learn more about our club
         </p>
       </div>
@@ -28,7 +31,7 @@ const AboutLanding = () => {
       <Image
         src={right}
         alt="rightring"
-        className="absolute -right-[7%] top-[32%] w-64 rotate-0"
+        className="absolute right-[-9%] top-[47%]  w-36 sm:-right-[5%] sm:top-[34%] sm:w-60 sm:rotate-1"
       />
     </div>
   );


### PR DESCRIPTION
Fix responsiveness that makes the landing page fit iPhone SE at least (below sm: size):
![image](https://github.com/acm-ucr/art-factory-website/assets/114966253/4f9eb65a-967d-4c43-9b65-927a605e20d4)

Landing page for above sm size:
![image](https://github.com/acm-ucr/art-factory-website/assets/114966253/66915ed7-1ee5-4503-b51d-a6efe2338ef8)

Since it was absolute, I made another absolute position that works for smaller than sm screens. I used the same code for the screen size above or equal to the sm size but made the small adjustment.

closes #67 