### PR TITLE
Fixed nav bar

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -15,7 +15,7 @@ const Navigation = () => {
   };
 
   return (
-    <div className="px-2 md:px-8 sticky py-3 top-0 z-30 bg-art-purple-100 w-screen flex justify-between items-center text-xl sm:text-xl md:text-xl lg:text-2xl">
+    <div className="px-2 md:px-8 sticky py-3 top-0 z-30 bg-art-purple-100 w-screen flex justify-between items-center text-xl sm:text-2xl md:text-xl lg:text-2xl">
       <Link
         onClick={() => {
           setSelected("");
@@ -30,28 +30,31 @@ const Navigation = () => {
         />
         Art Factory
       </Link>
-      <div className="hidden md:flex justify-end w-full pr-10 gap-4 space-x-2">
-        {" "}
-        {/* Add space-x-2 class */}
+      <div className="hidden md:flex justify-end w-full pr-2 gap-4 space-x-2">
         {items.map((item, index) => (
-          <Link
-            href={item.link}
-            key={index}
-            onClick={() => {
-              setSelected(item.name);
-              handleNav();
-            }}
-            className={`hover:text-pink-300 duration-300 border-solid font-semibold py-2 mx-2 ${
-              /* Add mx-2 class */
-              selected === item.name
-                ? ""
-                : item.name === "JOIN"
-                ? "bg-gradient-to-r from-art-pink-200 to-art-purple-200 rounded-full px-12 text-white"
-                : "text-white"
-            }`}
-          >
-            {item.name}
-          </Link>
+          <div key={index} className="relative">
+            <Link
+              href={item.link}
+              onClick={() => {
+                setSelected(item.name);
+                handleNav();
+              }}
+              className={`hover:text-art-pink-100 duration-300 border-solid font-semibold py-2 mx-2 ${
+                selected === item.name
+                  ? item.name === "JOIN"
+                    ? "bg-gradient-to-r from-art-pink-200 to-art-purple-200 rounded-full px-12 text-white"
+                    : "text-art-pink-100"
+                  : item.name === "JOIN"
+                  ? "bg-gradient-to-r from-art-pink-200 to-art-purple-200 rounded-full px-12 text-white"
+                  : "text-white"
+              }`}
+            >
+              {item.name}
+            </Link>
+            {selected === item.name && item.name !== "JOIN" && (
+              <div className="absolute bottom-[-8px] left-1/2 transform -translate-x-1/2 w-2 h-2 rounded-full bg-pink-300"></div>
+            )}
+          </div>
         ))}
       </div>
       {/* mobile menu */}
@@ -61,7 +64,7 @@ const Navigation = () => {
           nav
             ? "transition transform ease-out duration-500 translate-y-[68px] opacity-100"
             : "hidden transition duration-500 ease-in transform -translate-y-24 opacity-0"
-        } md:hidden flex flex-col items-center justify-evenly w-full duration-500 bg-white top-0 left-0 right-0 -z-10`}
+        } md:hidden flex flex-col items-center justify-evenly w-full duration-500 bg-art-purple-100 top-0 left-0 right-0 -z-10`}
       >
         {items.map((item, index) => (
           <Link
@@ -71,13 +74,17 @@ const Navigation = () => {
               setSelected(item.name);
               handleNav();
             }}
-            className={`hover:text-swim-blue-300 duration-300 border-solid font-semibold py-2 ${
+            className={`hover:text-art-pink-100 duration-300 border-solid font-semibold py-2 mx-2 ${
               selected === item.name
-                ? "border-b-2 border-swim-yellow text-swim-blue-300"
-                : "text-black"
+                ? item.name === "JOIN"
+                  ? "text-art-pink-100"
+                  : "text-art-pink-100"
+                : item.name === "JOIN"
+                ? "text-white"
+                : "text-white"
             }`}
           >
-            {item.name}
+            {item.name === "JOIN" ? "join" : item.name}
           </Link>
         ))}
       </div>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -10,8 +10,12 @@ const Navigation = () => {
   const [selected, setSelected] = useState("");
   const [nav, setNav] = useState(false);
 
+  const handleNav = () => {
+    setNav(!nav);
+  };
+
   return (
-    <div className="px-2 md:px-8 sticky py-3 top-0 z-30 bg-art-purple-100 w-screen flex justify-between items-center text-xl md:text-xl 2xl:text-2xl">
+    <div className="px-2 md:px-8 sticky py-3 top-0 z-30 bg-art-purple-100 w-screen flex justify-between items-center text-xl sm:text-xl md:text-xl lg:text-2xl">
       <Link
         onClick={() => {
           setSelected("");
@@ -26,7 +30,9 @@ const Navigation = () => {
         />
         Art Factory
       </Link>
-      <div className="hidden absolute right-0 md:flex justify-between w-2/5 pr-20 ">
+      <div className="hidden md:flex justify-end w-full pr-10 gap-4 space-x-2">
+        {" "}
+        {/* Add space-x-2 class */}
         {items.map((item, index) => (
           <Link
             href={item.link}
@@ -35,11 +41,12 @@ const Navigation = () => {
               setSelected(item.name);
               handleNav();
             }}
-            className={`hover:text-pink-300 duration-300 border-solid font-semibold py-2 ${
+            className={`hover:text-pink-300 duration-300 border-solid font-semibold py-2 mx-2 ${
+              /* Add mx-2 class */
               selected === item.name
                 ? ""
                 : item.name === "JOIN"
-                ? "bg-art-pink-200 rounded-full w-fit px-12 flex justify-center text-white"
+                ? "bg-gradient-to-r from-art-pink-200 to-art-purple-200 rounded-full px-12 text-white"
                 : "text-white"
             }`}
           >
@@ -74,7 +81,7 @@ const Navigation = () => {
           </Link>
         ))}
       </div>
-      <div onClick={() => setNav(!nav)}>
+      <div onClick={handleNav}>
         <FaBars className="text-3xl flex md:hidden text-white hover:cursor-pointer hover:text-swim-blue-300 justify-self-end" />
       </div>
     </div>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -15,22 +15,24 @@ const Navigation = () => {
   };
 
   return (
-    <div className="px-2 md:px-8 sticky py-3 top-0 z-30 bg-art-purple-100 w-screen flex justify-between items-center text-xl sm:text-2xl md:text-xl lg:text-2xl">
+    <div className="px-2 md:px-8 sticky py-3 top-0 z-30 bg-art-purple-100 w-screen flex justify-between items-center text-2xl sm:text-2xl md:text-xl lg:text-2xl">
       <Link
         onClick={() => {
           setSelected("");
         }}
         href="/"
-        className="flex gap-2 text-white items-center"
+        className="flex items-center"
       >
         <Image
           src={Logo}
           alt="Logo"
-          className="left-0 w-12 md:w-16 hover:opacity-60 duration-300 font-semibold"
+          className="left-0 w-12 md:w-14 lg:w-16 hover:opacity-60 duration-300 font-semibold"
         />
-        Art Factory
+        <span className="sm:text-2xl md:text-xl lg:text-2xl text-white whitespace-nowrap ml-2">
+          Art Factory
+        </span>
       </Link>
-      <div className="hidden md:flex justify-end w-full pr-2 gap-4 space-x-2">
+      <div className="hidden md:flex justify-end w-full gap-4 space-x-2">
         {items.map((item, index) => (
           <div key={index} className="relative">
             <Link

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -89,7 +89,11 @@ const Navigation = () => {
         ))}
       </div>
       <div onClick={handleNav}>
-        <FaBars className="text-3xl flex md:hidden text-white hover:cursor-pointer hover:text-swim-blue-300 justify-self-end" />
+        <FaBars
+          className={`text-3xl flex md:hidden ${
+            nav ? "text-art-pink-100" : "text-white"
+          } hover:cursor-pointer hover:text-art-pink-100 justify-self-end`}
+        />
       </div>
     </div>
   );

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -52,13 +52,12 @@ const Navigation = () => {
               {item.name}
             </Link>
             {selected === item.name && item.name !== "JOIN" && (
-              <div className="absolute bottom-[-8px] left-1/2 transform -translate-x-1/2 w-2 h-2 rounded-full bg-pink-300"></div>
+              <div className="absolute bottom-[-8px] left-1/2 transform -translate-x-1/2 w-2 h-2 rounded-full bg-art-pink-100"></div>
             )}
           </div>
         ))}
       </div>
       {/* mobile menu */}
-
       <div
         className={`fixed ${
           nav
@@ -75,16 +74,10 @@ const Navigation = () => {
               handleNav();
             }}
             className={`hover:text-art-pink-100 duration-300 border-solid font-semibold py-2 mx-2 ${
-              selected === item.name
-                ? item.name === "JOIN"
-                  ? "text-art-pink-100"
-                  : "text-art-pink-100"
-                : item.name === "JOIN"
-                ? "text-white"
-                : "text-white"
+              selected === item.name ? "text-art-pink-100" : "text-white"
             }`}
           >
-            {item.name === "JOIN" ? "join" : item.name}
+            {item.name}
           </Link>
         ))}
       </div>


### PR DESCRIPTION
Large screens and above uses text-2xl:
<img width="1440" alt="image" src="https://github.com/acm-ucr/art-factory-website/assets/74474117/bbcca5e0-79e2-4ee0-9fdd-010e5c136074">
Medium screens uses text-xl:
<img width="936" alt="image" src="https://github.com/acm-ucr/art-factory-website/assets/74474117/b0be2d27-63d1-4da9-a45c-ddd4245f968f">
Small screens uses text-2xl:
<img width="693" alt="image" src="https://github.com/acm-ucr/art-factory-website/assets/74474117/e15d54f5-6e53-4b96-beee-204faa6dda3f"> 
<img width="586" alt="image" src="https://github.com/acm-ucr/art-factory-website/assets/74474117/973476cd-92e3-44b1-acc7-27506ffd820e">

* Everything stays inside the nav bar and doesn't go outside like before
* Added a small gradient to JOIN
* Reimplemented dot when selected except for JOIN
* Did small changes to mobile menu to match desktop menu

